### PR TITLE
Fix leafpad.desktop.in add Keywords

### DIFF
--- a/data/l3afpad.desktop.in
+++ b/data/l3afpad.desktop.in
@@ -7,3 +7,5 @@ Terminal=false
 Type=Application
 MimeType=text/plain;
 Categories=GTK;Utility;TextEditor;
+Keywords=text;editor;
+InitialPreference=6;


### PR DESCRIPTION
This patch is for include Keywords and InitialPreference to .desktop file.

This .desktop file does either not contain a "Keywords" entry not contain any keywords entries.                                
Please consider applying the attached patch to include keyword entries.
Thanks.

kretcheu
[]'s
:x