### PR TITLE
set spacing so that page scroll does not overlap RTL text

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -58,6 +58,7 @@ MainWin *create_main_window(void)
 	gtk_box_pack_start(GTK_BOX(vbox), sw, TRUE, TRUE, 0);
 
 	mw->view = create_text_view();
+    gtk_container_set_border_width(GTK_CONTAINER(mw->view), 12);
 	gtk_container_add(GTK_CONTAINER(sw), mw->view);
 	mw->buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(mw->view));
 


### PR DESCRIPTION
Hi
when writing RTL text, page scroll bar covers beginning of text. I fixed that by adding a border to the right side of editor.

in this screenshot you can see that after this change, text is not under scroll bar anymore.
![image](https://user-images.githubusercontent.com/13185969/208108271-be5714ae-f7dd-4f0e-98a2-4566993bb69f.png)
