### PR TITLE
Use themed icon for the window

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -4,6 +4,3 @@ desktopdir       = $(datadir)/applications
 desktop_in_files = l3afpad.desktop.in
 desktop_DATA     = $(desktop_in_files:.desktop.in=.desktop)
 @INTLTOOL_DESKTOP_RULE@
-
-pixmapsdir       = $(datadir)/pixmaps
-pixmaps_DATA     = l3afpad.png l3afpad.xpm

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,5 @@
 bin_PROGRAMS = l3afpad
 
-AM_CPPFLAGS = -DICONDIR=\"$(datadir)/pixmaps\"
-
 l3afpad_SOURCES = \
 	l3afpad.h main.c \
 	window.h window.c \

--- a/src/window.c
+++ b/src/window.c
@@ -34,7 +34,6 @@ MainWin *create_main_window(void)
 	mw->window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
 	gtk_widget_set_name(mw->window, PACKAGE_NAME);
 
-	gtk_window_set_icon_from_file(GTK_WINDOW(mw->window), ICONDIR"/l3afpad.png", NULL);
 	gtk_window_set_default_icon_name(PACKAGE);
 
 	g_signal_connect(G_OBJECT(mw->window), "delete-event",


### PR DESCRIPTION
The default icon is already set by `gtk_window_set_default_icon_name()`, setting the window icon from the `pixmaps` directory is unnecessary.