### PR TITLE
Add margin below the overlay scrollbar

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -58,6 +58,7 @@ MainWin *create_main_window(void)
 	gtk_box_pack_start(GTK_BOX(vbox), sw, TRUE, TRUE, 0);
 
 	mw->view = create_text_view();
+	gtk_widget_set_margin_end(mw->view, 12);
 	gtk_container_add(GTK_CONTAINER(sw), mw->view);
 	mw->buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(mw->view));
 


### PR DESCRIPTION
This fixes the problem that the overlay scrollbar covers the text view. Especially useful with right-to-left layouts.