### PR TITLE
Use insensitive color for line numbers

### DIFF
--- a/src/linenum.c
+++ b/src/linenum.c
@@ -114,7 +114,7 @@ line_numbers_foreground_attr_new(GtkWidget *widget)
 	GdkRGBA          rgb;
 
 	context = gtk_widget_get_style_context(widget);
-	gtk_style_context_get_color(context, GTK_STATE_FLAG_NORMAL, &rgb);
+	gtk_style_context_get_color(context, GTK_STATE_FLAG_INSENSITIVE, &rgb);
 
 	return pango_attr_foreground_new((guint16)(rgb.red   * 65535),
 									 (guint16)(rgb.green * 65535),


### PR DESCRIPTION
Without this, the color of the line numbers is the same as the color of the text and difficult to distinguish.